### PR TITLE
if dir= is set, a ~/.ocra file will NOT be used

### DIFF
--- a/pam_ocra/pam_ocra.8
+++ b/pam_ocra/pam_ocra.8
@@ -26,7 +26,7 @@
 .\" SUCH DAMAGE.
 .\"
 .\"
-.Dd March 26, 2018
+.Dd April 9, 2018
 .Dt PAM_OCRA 8
 .Os
 .Sh NAME
@@ -55,7 +55,7 @@ The OCRA authentication component
 .Pq Fn pam_sm_authenticate
 obtains OCRA credentials from the the per-user file
 .Ar ~/.ocra .
-If this fails and the
+If the
 .Cm dir
 parameter is set,
 .Ar directory/USERNAME


### PR DESCRIPTION
fixes sg2342/pam_ocra#10